### PR TITLE
The coordinate system for the robot, field, and camera was incorrect ...

### DIFF
--- a/TeamCode/src/main/java/eaglesfe/common/PositionAwareAutonomous.java
+++ b/TeamCode/src/main/java/eaglesfe/common/PositionAwareAutonomous.java
@@ -35,11 +35,16 @@ public abstract class PositionAwareAutonomous extends LinearOpMode {
         return new Geometry.Point3(0,0,0);
     }
 
+    /**
+     * Sets the Z angle of the tracking camera. 0 degrees = RIGHT, 90 = FORWARD, etc.
+     */
+    protected int getCameraAngle() { return 90; }
+
     // Make sure you call super.runOpMode() in your derived class.
     @Override
     public void runOpMode() {
         Geometry.Point3 cameraPosition = getCameraPositionOnRobot();
-        positionEstimator = new RoverRuckusRobotPositionEstimator(cameraPosition.y, cameraPosition.x, cameraPosition.z);
+        positionEstimator = new RoverRuckusRobotPositionEstimator(cameraPosition.y, cameraPosition.x, cameraPosition.z, getCameraAngle());
         positionEstimator.initialize(hardwareMap, shouldUseWebcam(), shouldShowCameraPreview());
         positionEstimator.start();
     }

--- a/TeamCode/src/main/java/eaglesfe/common/PositionAwareTeleOp.java
+++ b/TeamCode/src/main/java/eaglesfe/common/PositionAwareTeleOp.java
@@ -37,11 +37,16 @@ public abstract class PositionAwareTeleOp extends OpMode {
         return new Geometry.Point3(0,0,0);
     }
 
+    /**
+     * Sets the Z angle of the tracking camera. 0 degrees = RIGHT, 90 = FORWARD, etc.
+     */
+    protected int getCameraAngle() { return 90; }
+
     // Make sure you call super.init() in your derived class.
     @Override
     public void init() {
         Geometry.Point3 cameraPosition = getCameraPositionOnRobot();
-        positionEstimator = new RoverRuckusRobotPositionEstimator(cameraPosition.y, cameraPosition.x, cameraPosition.z);
+        positionEstimator = new RoverRuckusRobotPositionEstimator(cameraPosition.y, cameraPosition.x, cameraPosition.z, getCameraAngle());
         positionEstimator.initialize(this.hardwareMap, shouldUseWebcam(), shouldShowCameraPreview());
         positionEstimator.start();
     }

--- a/TeamCode/src/main/java/eaglesfe/common/RobotPosition.java
+++ b/TeamCode/src/main/java/eaglesfe/common/RobotPosition.java
@@ -28,13 +28,13 @@ public class RobotPosition {
         this(matrix.getTranslation(), Orientation.getOrientation(matrix, AxesReference.EXTRINSIC, AxesOrder.XYZ, AngleUnit.DEGREES));
     }
 
-    RobotPosition(VectorF translation, Orientation rotation){
+    private RobotPosition(VectorF translation, Orientation rotation){
         this.x = translation.get(0) / VuforiaBase.MM_PER_INCH;
         this.y = translation.get(1) / VuforiaBase.MM_PER_INCH;
         this.z = translation.get(2) / VuforiaBase.MM_PER_INCH;
 
-        this.roll = rotation.firstAngle;
-        this.pitch = rotation.secondAngle;
+        this.roll = rotation.firstAngle * -1;
+        this.pitch = rotation.secondAngle * -1;
         this.heading = rotation.thirdAngle;
     }
 
@@ -44,20 +44,23 @@ public class RobotPosition {
 
     public void addToTelemetry(Telemetry telemetry, boolean immediateUpdate){
         boolean isKnown = isKnown();
-        String positionFormatter = isKnown ? "{X, Y, Z} = %.1f, %.1f, %.1f" : "Unknown";
-        String rotationFormatter = isKnown ? "{R, P, H} = %.0f, %.0f, %.0f" : "Unknown";
-        telemetry.addData("Pos (in)", positionFormatter, x, y, z);
-        telemetry.addData("Rot (deg)", rotationFormatter, roll, pitch, heading);
+        String positionFormatter = isKnown ? "X: %-10.1f Y: %-10.1f Z: %-10.1f" : "Unknown";
+        String rotationFormatter = isKnown ? "R: %-10.1f P: %-10.1f H: %-10.1f" : "Unknown";
+        telemetry.addData("", positionFormatter, x, y, z);
+        telemetry.addData("", rotationFormatter, roll, pitch, heading);
 
         if (immediateUpdate){
             telemetry.update();
         }
     }
 
+    /* To help in constructing a mental model, these four properties are relative to the FIELD's coordinate system... */
     public float x;
     public float y;
     public float z;
+    public float heading;
+
+    /* ... and these two properties are relative to the ROBOT's coordinate system */
     public float pitch;
     public float roll;
-    public float heading;
 }

--- a/TeamCode/src/main/java/eaglesfe/common/RoverRuckusRobotPositionEstimator.java
+++ b/TeamCode/src/main/java/eaglesfe/common/RoverRuckusRobotPositionEstimator.java
@@ -56,7 +56,7 @@ public class RoverRuckusRobotPositionEstimator
 
         parameters.vuforiaLicenseKey = VUFORIA_KEY ;
         if (useWebcam){
-            parameters.cameraName = hardwareMap.get(WebcamName.class, "Webcam");
+            parameters.cameraName = hardwareMap.getAll(WebcamName.class).get(0);
         }
         else {
             parameters.cameraDirection  = CameraDirection.BACK;
@@ -97,18 +97,28 @@ public class RoverRuckusRobotPositionEstimator
                 .multiplied(Orientation.getRotationMatrix(AxesReference.EXTRINSIC, AxesOrder.XYZ, AngleUnit.DEGREES, 90, 0, -90));
         backSpace.setLocation(backSpaceLocationOnField);
 
-        // For convenience, gather together all the trackable objects in one easily-iterable collection */
         trackables = new ArrayList<>();
         trackables.addAll(targetsRoverRuckus);
 
-        OpenGLMatrix phoneLocationOnRobot = OpenGLMatrix
-                .translation(cameraForwardOffsetMm, cameraLeftOffsetMm, cameraVerticalOffsetMm)
-                .multiplied(Orientation.getRotationMatrix(AxesReference.EXTRINSIC, AxesOrder.YZX, AngleUnit.DEGREES,
-                        -90, 0, 0));
+        if (useWebcam){
+            OpenGLMatrix cameraLocationOnRobot = OpenGLMatrix
+                    .translation(cameraForwardOffsetMm, cameraLeftOffsetMm, cameraVerticalOffsetMm)
+                    .multiplied(Orientation.getRotationMatrix(AxesReference.EXTRINSIC, AxesOrder.XZY, AngleUnit.DEGREES, 90, 90, 0));
 
-        for (VuforiaTrackable trackable : trackables)
-        {
-            ((VuforiaTrackableDefaultListener)trackable.getListener()).setPhoneInformation(phoneLocationOnRobot, parameters.cameraDirection);
+            for (VuforiaTrackable trackable : trackables)
+            {
+                ((VuforiaTrackableDefaultListener)trackable.getListener()).setCameraLocationOnRobot(parameters.cameraName, cameraLocationOnRobot);
+            }
+        }
+        else {
+            OpenGLMatrix phoneLocationOnRobot = OpenGLMatrix
+                    .translation(cameraForwardOffsetMm, cameraLeftOffsetMm, cameraVerticalOffsetMm)
+                    .multiplied(Orientation.getRotationMatrix(AxesReference.EXTRINSIC, AxesOrder.YZX, AngleUnit.DEGREES, -90, 0, 0));
+
+            for (VuforiaTrackable trackable : trackables)
+            {
+                ((VuforiaTrackableDefaultListener)trackable.getListener()).setPhoneInformation(phoneLocationOnRobot, parameters.cameraDirection);
+            }
         }
 
         isInitialized = true;

--- a/TeamCode/src/main/java/eaglesfe/common/RoverRuckusRobotPositionEstimator.java
+++ b/TeamCode/src/main/java/eaglesfe/common/RoverRuckusRobotPositionEstimator.java
@@ -32,15 +32,17 @@ public class RoverRuckusRobotPositionEstimator
     private int cameraForwardOffsetMm;
     private int cameraVerticalOffsetMm;
     private int cameraLeftOffsetMm;
+    private int cameraAngleOffsetDeg;
 
     RoverRuckusRobotPositionEstimator() {
-        this(0,0,0);
+        this(0,0,0, 90);
     }
 
-    RoverRuckusRobotPositionEstimator(float cameraForwardOffset, float cameraLeftOffset, float cameraVerticalOffset) {
+    RoverRuckusRobotPositionEstimator(float cameraForwardOffset, float cameraLeftOffset, float cameraVerticalOffset, int cameraAngle) {
         this.cameraForwardOffsetMm = (int)(cameraForwardOffset * VuforiaBase.MM_PER_INCH);
         this.cameraVerticalOffsetMm = (int)(cameraVerticalOffset * VuforiaBase.MM_PER_INCH);
         this.cameraLeftOffsetMm = (int)(cameraLeftOffset * VuforiaBase.MM_PER_INCH);
+        this.cameraAngleOffsetDeg = cameraAngle;
     }
 
     public void initialize(HardwareMap hardwareMap, boolean useWebcam, boolean preview){
@@ -103,7 +105,7 @@ public class RoverRuckusRobotPositionEstimator
         if (useWebcam){
             OpenGLMatrix cameraLocationOnRobot = OpenGLMatrix
                     .translation(cameraForwardOffsetMm, cameraLeftOffsetMm, cameraVerticalOffsetMm)
-                    .multiplied(Orientation.getRotationMatrix(AxesReference.EXTRINSIC, AxesOrder.XZY, AngleUnit.DEGREES, 90, 90, 0));
+                    .multiplied(Orientation.getRotationMatrix(AxesReference.EXTRINSIC, AxesOrder.XZY, AngleUnit.DEGREES, 90, cameraAngleOffsetDeg, 0));
 
             for (VuforiaTrackable trackable : trackables)
             {
@@ -113,7 +115,7 @@ public class RoverRuckusRobotPositionEstimator
         else {
             OpenGLMatrix phoneLocationOnRobot = OpenGLMatrix
                     .translation(cameraForwardOffsetMm, cameraLeftOffsetMm, cameraVerticalOffsetMm)
-                    .multiplied(Orientation.getRotationMatrix(AxesReference.EXTRINSIC, AxesOrder.YZX, AngleUnit.DEGREES, -90, 0, 0));
+                    .multiplied(Orientation.getRotationMatrix(AxesReference.EXTRINSIC, AxesOrder.YZX, AngleUnit.DEGREES, -90, cameraAngleOffsetDeg - 90, 0));
 
             for (VuforiaTrackable trackable : trackables)
             {


### PR DESCRIPTION
…in the FTC-provided example. This change corrects the position estimator (more specifically the RobotPosition itself) to correct for the misleading tutelage. I've also improved the readability of the telemetry information provided by RobotPosition. Finally, the PositionEstimator will now use the first webcam that gets enumerated rather than using a hardcoded name. This means that it doesnt matter what the name of the camera is in the robot config, but it also means that if you have more than one, we may use the wrong one.